### PR TITLE
Return a 500 for thrown errors

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -64,13 +64,23 @@ const getContribWelcomeBugs = async (req, res) => {
   res.json(contribWelcomeBugs);
 };
 
-app.get('/api/projects/', getProjects);
-app.get('/api/team/', getTeam);
-app.get('/api/issue-counts/', getIssueCounts);
-app.get('/api/good-first-bugs/', getGoodFirstBugs);
-app.get('/api/maybe-good-first-bugs/', getMaybeGoodFirstBugs);
-app.get('/api/milestone-issues/', getMilestoneIssues);
-app.get('/api/contrib-welcome/', getContribWelcomeBugs);
+function handleErrors(processRequest) {
+  return async (req, res, next) => {
+    try {
+      await processRequest(req, res, next);
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+app.get('/api/projects/', handleErrors(getProjects));
+app.get('/api/team/', handleErrors(getTeam));
+app.get('/api/issue-counts/', handleErrors(getIssueCounts));
+app.get('/api/good-first-bugs/', handleErrors(getGoodFirstBugs));
+app.get('/api/maybe-good-first-bugs/', handleErrors(getMaybeGoodFirstBugs));
+app.get('/api/milestone-issues/', handleErrors(getMilestoneIssues));
+app.get('/api/contrib-welcome/', handleErrors(getContribWelcomeBugs));
 
 function startServer() {
   let portOrSocket = process.env.PORT || 5000;


### PR DESCRIPTION
Whenever I made a mistake in a graphql query, the API would never respond. In the console of the server, there was an uncaught promise rejection. I'm not totally sure if this will happen in production but I think it will.

The fix is simple: just call `next(error)` for all handlers. Since `supertest` (or the equivalent) wasn't set up, there wasn't an easy way to test it but I guess this is a start.