### PR TITLE
Update travis to do style linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ cache:
 script:
   - npm run prettier-ci
   - npm run lint
+  - npm run stylelint
   - npm run test-ci
   - npm run build


### PR DESCRIPTION
Run stylelint on CI - this should fail CI when it runs.

Which it did:

<img width="894" alt="Update_travis_to_do_style_linting_by_muffinresearch_·_Pull_Request__382_·_mozilla_addons-pm" src="https://user-images.githubusercontent.com/1514/94928242-4c464080-04bb-11eb-8586-a858435d33a8.png">

Now, once rebased, it should pass as the fix has been provided in another branch:

