### PR TITLE
Add addons-blog repo and prod_bugs

### DIFF
--- a/components/AMODashCount.js
+++ b/components/AMODashCount.js
@@ -15,6 +15,11 @@ export default function AMODashCount(props) {
       -label%3A%22priority%3A%20p4%22%20-label%3A%22priority%3A%20p5%22`;
     warningLimit = 15;
   }
+  if (props.title.includes('prod_bug')) {
+    issuesLink = oneLineTrim`https://github.com/mozilla/${repo}/issues?
+      utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3A%22type%3A%20prod_bug%22`;
+    warningLimit = 1;
+  }
   if (props.title.includes('p1')) {
     issuesLink = oneLineTrim`https://github.com/mozilla/${repo}/issues?
       utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3A%22priority:%20p1%22`;

--- a/lib/const.js
+++ b/lib/const.js
@@ -52,6 +52,7 @@ module.exports = {
   contribRepos: [
     'mozilla/addons',
     'mozilla/addons-code-manager',
+    'mozilla/addons-blog',
     'mozilla/addons-server',
     'mozilla/addons-frontend',
     'mozilla/addons-linter',

--- a/lib/const.js
+++ b/lib/const.js
@@ -68,6 +68,7 @@ module.exports = {
     products: ['Toolkit', 'WebExtensions', 'Firefox'],
     whiteboardTags: [
       'addons-ux',
+      'prod_bugs',
       'stockwell disable-recommended',
       'stockwell fixed',
       'stockwell disabled',

--- a/pages/api/gh-issue-counts.js
+++ b/pages/api/gh-issue-counts.js
@@ -19,6 +19,9 @@ const query = gql`
     ) {
       totalCount
     }
+    open_prod_bugs: issues(states: OPEN, labels: "type: prod_bug") {
+      totalCount
+    }
     open_p1s: issues(states: OPEN, labels: "priority: p1") {
       totalCount
     }
@@ -41,6 +44,9 @@ const query = gql`
       ...issueCounts
     }
     addons_frontend: repository(name: "addons-frontend", owner: "mozilla") {
+      ...issueCounts
+    }
+    addons_blog: repository(name: "addons-blog", owner: "mozilla") {
       ...issueCounts
     }
     addons_linter: repository(name: "addons-linter", owner: "mozilla") {

--- a/pages/api/gh-milestone-issues.js
+++ b/pages/api/gh-milestone-issues.js
@@ -85,6 +85,7 @@ export default async (req, res) => {
       query: `repo:mozilla/addons
       repo:mozilla/addons-server
       repo:mozilla/addons-frontend
+      repo:mozilla/addons-blog
       repo:mozilla/addons-linter
       repo:mozilla/addons-code-manager
       milestone:${milestone}

--- a/pages/dashboards/webext.js
+++ b/pages/dashboards/webext.js
@@ -242,7 +242,7 @@ function DashboardWE(props) {
       );
     });
 
-    children.push(<DashBlank key="ni-blank-1" />);
+    // children.push(<DashBlank key="ni-blank-1" />);
 
     return DashCountGroup({
       className: 'whiteboardtags',

--- a/pages/dashboards/webext.js
+++ b/pages/dashboards/webext.js
@@ -242,8 +242,6 @@ function DashboardWE(props) {
       );
     });
 
-    // children.push(<DashBlank key="ni-blank-1" />);
-
     return DashCountGroup({
       className: 'whiteboardtags',
       key: 'whiteboardtags',

--- a/tests/fixtures/bz-whiteboard-tags.js
+++ b/tests/fixtures/bz-whiteboard-tags.js
@@ -4,9 +4,9 @@ export default {
     url:
       'https://bugzilla.mozilla.org/buglist.cgi?bug_status=ASSIGNED&bug_status=NEW&bug_status=REOPENED&bug_status=UNCONFIRMED&component=Add-ons%20Manager&component=Android&component=Compatibility&component=Developer%20Outreach&component=Developer%20Tools&component=Experiments&component=Frontend&component=General&component=Request%20Handling&component=Storage&component=Themes&component=Untriaged&product=Toolkit&product=WebExtensions&resolution=---&status_whiteboard=addons-ux&status_whiteboard_type=allwordssubstr',
   },
-  'prod_bugs': {
-    'count': 4,
-    'url':
+  prod_bugs: {
+    count: 4,
+    url:
       'https://bugzilla.mozilla.org/buglist.cgi?bug_status=ASSIGNED&bug_status=NEW&bug_status=REOPENED&bug_status=UNCONFIRMED&component=Add-ons%20Manager&component=Android&component=Compatibility&component=Developer%20Outreach&component=Developer%20Tools&component=Experiments&component=Frontend&component=General&component=Request%20Handling&component=Storage&component=Themes&component=Untriaged&product=Toolkit&product=WebExtensions&resolution=---&status_whiteboard=prod_bugs&status_whiteboard_type=allwordssubstr',
   },
   'stockwell disable-recommended': {

--- a/tests/fixtures/bz-whiteboard-tags.js
+++ b/tests/fixtures/bz-whiteboard-tags.js
@@ -4,6 +4,11 @@ export default {
     url:
       'https://bugzilla.mozilla.org/buglist.cgi?bug_status=ASSIGNED&bug_status=NEW&bug_status=REOPENED&bug_status=UNCONFIRMED&component=Add-ons%20Manager&component=Android&component=Compatibility&component=Developer%20Outreach&component=Developer%20Tools&component=Experiments&component=Frontend&component=General&component=Request%20Handling&component=Storage&component=Themes&component=Untriaged&product=Toolkit&product=WebExtensions&resolution=---&status_whiteboard=addons-ux&status_whiteboard_type=allwordssubstr',
   },
+  'prod_bugs': {
+    'count': 4,
+    'url':
+      'https://bugzilla.mozilla.org/buglist.cgi?bug_status=ASSIGNED&bug_status=NEW&bug_status=REOPENED&bug_status=UNCONFIRMED&component=Add-ons%20Manager&component=Android&component=Compatibility&component=Developer%20Outreach&component=Developer%20Tools&component=Experiments&component=Frontend&component=General&component=Request%20Handling&component=Storage&component=Themes&component=Untriaged&product=Toolkit&product=WebExtensions&resolution=---&status_whiteboard=prod_bugs&status_whiteboard_type=allwordssubstr',
+  },
   'stockwell disable-recommended': {
     count: 4,
     url:

--- a/tests/fixtures/gh-issue-counts.js
+++ b/tests/fixtures/gh-issue-counts.js
@@ -10,6 +10,10 @@ export default {
         totalCount: 102,
         __typename: 'IssueConnection',
       },
+      open_prod_bugs: {
+        totalCount: 0,
+        __typename: 'IssueConnection',
+      },
       open_p1s: {
         totalCount: 0,
         __typename: 'IssueConnection',
@@ -36,6 +40,10 @@ export default {
       },
       triaged: {
         totalCount: 380,
+        __typename: 'IssueConnection',
+      },
+      open_prod_bugs: {
+        totalCount: 0,
         __typename: 'IssueConnection',
       },
       open_p1s: {
@@ -66,6 +74,10 @@ export default {
         totalCount: 357,
         __typename: 'IssueConnection',
       },
+      open_prod_bugs: {
+        totalCount: 0,
+        __typename: 'IssueConnection',
+      },
       open_p1s: {
         totalCount: 0,
         __typename: 'IssueConnection',
@@ -84,6 +96,38 @@ export default {
       },
       __typename: 'Repository',
     },
+    addons_blog: {
+      description: 'Blog content builder for AMO',
+      total_issues: {
+        totalCount: 3,
+        __typename: 'IssueConnection',
+      },
+      triaged: {
+        totalCount: 0,
+        __typename: 'IssueConnection',
+      },
+      open_prod_bugs: {
+        totalCount: 0,
+        __typename: 'IssueConnection',
+      },
+      open_p1s: {
+        totalCount: 0,
+        __typename: 'IssueConnection',
+      },
+      open_p2s: {
+        totalCount: 0,
+        __typename: 'IssueConnection',
+      },
+      open_p3s: {
+        totalCount: 0,
+        __typename: 'IssueConnection',
+      },
+      open_prs: {
+        totalCount: 0,
+        __typename: 'PullRequestConnection',
+      },
+      __typename: 'Repository',
+    },
     addons_linter: {
       description: '🔍 Firefox Add-ons linter, written in JavaScript. 👁',
       total_issues: {
@@ -92,6 +136,10 @@ export default {
       },
       triaged: {
         totalCount: 86,
+        __typename: 'IssueConnection',
+      },
+      open_prod_bugs: {
+        totalCount: 0,
         __typename: 'IssueConnection',
       },
       open_p1s: {
@@ -120,6 +168,10 @@ export default {
       },
       triaged: {
         totalCount: 53,
+        __typename: 'IssueConnection',
+      },
+      open_prod_bugs: {
+        totalCount: 0,
         __typename: 'IssueConnection',
       },
       open_p1s: {

--- a/tests/pages/dashboards/amo.test.js
+++ b/tests/pages/dashboards/amo.test.js
@@ -26,6 +26,6 @@ describe(__filename, () => {
 
     // All the dashgroups.
     const cardGroups = await findAllByText(/.*?/, { selector: '.card-grp' });
-    expect(cardGroups).toHaveLength(5);
+    expect(cardGroups).toHaveLength(6);
   });
 });


### PR DESCRIPTION
Fixes #531
Fixes #532

This patch add the addons-blog repo and represents the github label `type: prod_bug` and the whiteboard tag `prod_bug`.

